### PR TITLE
fix: Add CATEGORY:PREVIEW to Arcjet bot detection allowlist

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -16,12 +16,12 @@ const aj = arcjet({
     shield({
       mode: "LIVE", // Change to "DRY_RUN" for testing
     }),
-    // Detect and block automated bots - STRICT MODE
+    // Detect and block automated bots - Allow search engines and preview services
     detectBot({
       mode: "LIVE",
       allow: [
         "CATEGORY:SEARCH_ENGINE", // Allow Google, Bing, DuckDuckGo, etc.
-        // Removed CATEGORY:PREVIEW and CATEGORY:MONITOR for stricter filtering
+        "CATEGORY:PREVIEW", // Allow Vercel, social media preview bots
       ],
       // Block all other automated requests including curl, wget, python-requests, etc.
       block: [


### PR DESCRIPTION
- Added CATEGORY:PREVIEW to Arcjet detectBot allow list
- Fixes Vercel preview crawler being blocked by Arcjet
- Vercel can now generate deployment screenshot previews
- Social media preview bots (Twitter, Facebook, LinkedIn) also allowed
- curl and automation tools still blocked via CATEGORY:AUTOMATED

Root cause: Arcjet blocked preview bots before manual User-Agent check ran