### PR TITLE
fix: Theme switching now works instantly from Cyber theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,12 @@ export default function RootLayout({
         <AuthSync />
         {/* Client-side security protections */}
         <ClientSecurityProtection />
-        <ThemeProvider attribute="class" defaultTheme="cyber">
+        <ThemeProvider 
+          attribute="class" 
+          defaultTheme="cyber" 
+          enableSystem={false}
+          themes={['light', 'dark', 'cyber']}
+        >
           <div className="flex min-h-screen flex-col">
             <Navbar />
             <main className="flex-1">{children}</main>


### PR DESCRIPTION
- Added explicit themes array ['light', 'dark', 'cyber'] to ThemeProvider
- Disabled enableSystem to prevent OS preference conflicts
- Cyber theme now switches to Light/Dark instantly without refresh
- All theme combinations now work bidirectionally