### PR TITLE
fix: Set system (OS preference) as default theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,8 +39,8 @@ export default function RootLayout({
         <ClientSecurityProtection />
         <ThemeProvider 
           attribute="class" 
-          defaultTheme="cyber" 
-          enableSystem={false}
+          defaultTheme="system" 
+          enableSystem={true}
           themes={['light', 'dark', 'cyber']}
         >
           <div className="flex min-h-screen flex-col">


### PR DESCRIPTION
- Changed defaultTheme from 'cyber' to 'system'
- Enabled enableSystem to follow OS dark/light mode
- Users now see their OS preference on first visit
- All themes (Light, Dark, Cyber) still manually selectable