### PR TITLE
fix: Improve attack log display speed and reliability

### DIFF
--- a/app/api/attack-logs/route.ts
+++ b/app/api/attack-logs/route.ts
@@ -4,11 +4,18 @@ import { attackLogs } from '@/lib/db';
 import { desc } from 'drizzle-orm';
 
 export const dynamic = 'force-dynamic';
+export const revalidate = 0; // Disable caching
 
 export async function GET() {
   try {
-    const logs = await db.select().from(attackLogs).orderBy(desc(attackLogs.timestamp)).limit(20);
-    return NextResponse.json(logs);
+    const logs = await db.select().from(attackLogs).orderBy(desc(attackLogs.timestamp)).limit(50);
+    return NextResponse.json(logs, {
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+      },
+    });
   } catch (error) {
     console.error('Error fetching attack logs:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -225,7 +225,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(fetchData, 30000);
+    const interval = setInterval(fetchData, 5000); // Poll every 5 seconds for real-time updates
     return () => clearInterval(interval);
   }, [fetchData]);
 


### PR DESCRIPTION
Changes:
1. Dashboard: Reduced polling interval from 30s to 5s for real-time updates
2. API: Added no-cache headers to prevent browser/CDN caching
3. API: Increased limit from 20 to 50 logs
4. Chatbot: Changed geo-location from INSERT (duplicate) to UPDATE (same record)
5. Chatbot: Added 3-second timeout for geo-lookup to prevent hangs

Attack logs now appear in dashboard within 5 seconds of detection.